### PR TITLE
Parse query string params to single values (not lists) in `get_authorize_url` method

### DIFF
--- a/quickbooks/client.py
+++ b/quickbooks/client.py
@@ -1,9 +1,9 @@
 try:  # Python 3
     import http.client as httplib
-    from urllib.parse import parse_qs
+    from urllib.parse import parse_qsl
 except ImportError:  # Python 2
     import httplib
-    from urlparse import parse_qs
+    from urlparse import parse_qsl
 
 from .exceptions import QuickbooksException, SevereException
 
@@ -120,9 +120,10 @@ class QuickBooks(object):
             self.set_up_service()
 
         response = self.qbService.get_raw_request_token(
-           params={'oauth_callback': self.callback_url})
+           params={'oauth_callback': self.callback_url}
+        )
 
-        oauth_resp = parse_qs(response.text)
+        oauth_resp = dict(parse_qsl(response.text))
 
         self.request_token = oauth_resp['oauth_token']
         self.request_token_secret = oauth_resp['oauth_token_secret']


### PR DESCRIPTION
A fix for issue #8 