### PR TITLE
Add Class object

### DIFF
--- a/quickbooks/objects/trackingclass.py
+++ b/quickbooks/objects/trackingclass.py
@@ -1,0 +1,38 @@
+from six import python_2_unicode_compatible
+from .base import QuickbooksManagedObject, QuickbooksTransactionEntity, Ref
+
+
+@python_2_unicode_compatible
+class TrackingClass(QuickbooksManagedObject, QuickbooksTransactionEntity):
+    """
+    QBO definition: Classes provide a way to track different segments of the business so they're
+    not tied to a particular client or project. For example, you can define classes to break down
+    the income and expenses for each business segment. Classes are applied to individual detail
+    lines of a transaction. This is in contrast to Department objects, which are applied to the
+    entire transaction.
+    """
+
+    class_dict = {
+        "ParentRef": Ref
+    }
+
+    qbo_object_name = "Class"
+
+    def __init__(self):
+        super(TrackingClass, self).__init__()
+        self.Name = ""
+        self.SubClass = False
+        self.FullyQualifiedName = ""
+        self.Active = True
+
+    def __str__(self):
+        return self.Name
+
+    def to_ref(self):
+        ref = Ref()
+
+        ref.name = self.Name
+        ref.type = self.qbo_object_name
+        ref.value = self.Id
+
+        return ref

--- a/tests/unit/objects/test_trackingclass.py
+++ b/tests/unit/objects/test_trackingclass.py
@@ -1,0 +1,22 @@
+import unittest
+
+from quickbooks.objects.trackingclass import TrackingClass
+
+
+class TrackingClassTests(unittest.TestCase):
+    def test_unicode(self):
+        cls = TrackingClass()
+        cls.Name = "test"
+
+        self.assertEquals(str(cls), "test")
+
+    def test_to_ref(self):
+        cls = TrackingClass()
+        cls.Name = "test"
+        cls.Id = 100
+
+        dept_ref = cls.to_ref()
+
+        self.assertEquals(dept_ref.name, "test")
+        self.assertEquals(dept_ref.type, "Class")
+        self.assertEquals(dept_ref.value, 100)


### PR DESCRIPTION
I needed access to list/create the `Class` objects in quickbooks. It's a pain since that is a reserved word in python, which I assume is why this object was left out in the first place.

Anyway, I just called it `TrackingClass` to avoid any conflicts. Let me know if you can think of a better name.