### PR TITLE
adding QuickBooks.disable_global and 'qb' arg to mixin methods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ pip-delete-this-directory.txt
 
 # Unit test / coverage reports
 htmlcov/
+.env
 .tox/
 .coverage
 .coverage.*

--- a/quickbooks/batch.py
+++ b/quickbooks/batch.py
@@ -14,13 +14,13 @@ class BatchManager(object):
         else:
             raise QuickbooksException("Operation not supported.")
 
-    def save(self, obj_list):
+    def save(self, obj_list, qb=None):
         batch_response = BatchResponse()
 
         while len(obj_list) > 0:
             temp_list = obj_list[:self._max_request_items]
             obj_list = [item for item in obj_list if item not in temp_list]
-            result = self.process_batch(temp_list)
+            result = self.process_batch(temp_list, qb=qb)
 
             batch_response.batch_responses += result.batch_responses
             batch_response.original_list += result.original_list
@@ -29,8 +29,9 @@ class BatchManager(object):
 
         return batch_response
 
-    def process_batch(self, obj_list):
-        qb = QuickBooks()
+    def process_batch(self, obj_list, qb=None):
+        if not qb:
+            qb = QuickBooks()
 
         batch = self.list_to_batch_request(obj_list)
         json_data = qb.batch_operation(batch.to_json())
@@ -75,16 +76,16 @@ class BatchManager(object):
         return response
 
 
-def batch_create(obj_list):
+def batch_create(obj_list, qb=None):
     batch_mgr = BatchManager(BatchOperation.CREATE)
-    return batch_mgr.save(obj_list)
+    return batch_mgr.save(obj_list, qb=qb)
 
 
-def batch_update(obj_list):
+def batch_update(obj_list, qb=None):
     batch_mgr = BatchManager(BatchOperation.UPDATE)
-    return batch_mgr.save(obj_list)
+    return batch_mgr.save(obj_list, qb=qb)
 
 
-def batch_delete(obj_list):
+def batch_delete(obj_list, qb=None):
     batch_mgr = BatchManager(BatchOperation.DELETE)
-    return batch_mgr.save(obj_list)
+    return batch_mgr.save(obj_list, qb=qb)

--- a/quickbooks/client.py
+++ b/quickbooks/client.py
@@ -52,40 +52,63 @@ class QuickBooks(object):
     ]
 
     __instance = None
+    __use_global = True
 
     def __new__(cls, **kwargs):
-        if QuickBooks.__instance is None:
-            QuickBooks.__instance = object.__new__(cls)
+        """
+        If global is disabled, don't set global client instance.
+        """
+        if QuickBooks.__use_global:
+            if QuickBooks.__instance is None:
+                QuickBooks.__instance = object.__new__(cls)
+            instance = QuickBooks.__instance
+        else:
+            instance = object.__new__(cls)
 
         if 'consumer_key' in kwargs:
-            cls.consumer_key = kwargs['consumer_key']
+            instance.consumer_key = kwargs['consumer_key']
 
         if 'consumer_secret' in kwargs:
-            cls.consumer_secret = kwargs['consumer_secret']
+            instance.consumer_secret = kwargs['consumer_secret']
 
         if 'access_token' in kwargs:
-            cls.access_token = kwargs['access_token']
+            instance.access_token = kwargs['access_token']
 
         if 'access_token_secret' in kwargs:
-            cls.access_token_secret = kwargs['access_token_secret']
+            instance.access_token_secret = kwargs['access_token_secret']
 
         if 'company_id' in kwargs:
-            cls.company_id = kwargs['company_id']
+            instance.company_id = kwargs['company_id']
 
         if 'callback_url' in kwargs:
-            cls.callback_url = kwargs['callback_url']
+            instance.callback_url = kwargs['callback_url']
 
         if 'sandbox' in kwargs:
-            cls.sandbox = kwargs['sandbox']
+            instance.sandbox = kwargs['sandbox']
 
         if 'minorversion' in kwargs:
-            cls.minorversion = kwargs['minorversion']
+            instance.minorversion = kwargs['minorversion']
 
-        return QuickBooks.__instance
+        return instance
 
     @classmethod
     def get_instance(cls):
         return cls.__instance
+
+    @classmethod
+    def disable_global(cls):
+        """
+        Disable use of singleton pattern.
+        """
+        QuickBooks.__use_global = False
+        QuickBooks.__instance = None
+
+    @classmethod
+    def enable_global(cls):
+        """
+        Allow use of singleton pattern.
+        """
+        QuickBooks.__use_global = True
 
     def _drop(self):
         QuickBooks.__instance = None

--- a/quickbooks/client.py
+++ b/quickbooks/client.py
@@ -206,8 +206,11 @@ class QuickBooks(object):
         except:
             raise QuickbooksException("Error reading json response: {0}".format(req.text), 10000)
 
-        if req.status_code is not httplib.OK or "Fault" in result:
+        if "Fault" in result:
             self.handle_exceptions(result["Fault"])
+        elif not req.status_code == httplib.OK:
+            raise QuickbooksException("Error returned with status code '{0}': {1}".format(
+                req.status_code, req.text), 10000)
         else:
             return result
 

--- a/quickbooks/client.py
+++ b/quickbooks/client.py
@@ -5,7 +5,7 @@ except ImportError:  # Python 2
     import httplib
     from urlparse import parse_qsl
 
-from .exceptions import QuickbooksException, SevereException
+from .exceptions import QuickbooksException, SevereException, AuthorizationException
 
 try:
     from rauth import OAuth1Session, OAuth1Service
@@ -198,6 +198,8 @@ class QuickBooks(object):
         }
 
         req = self.session.request(request_type, url, True, self.company_id, headers=headers, params=params, data=request_body)
+        if req.status_code == httplib.UNAUTHORIZED:
+            raise AuthorizationException("Application authentication failed")
 
         try:
             result = req.json()

--- a/quickbooks/mixins.py
+++ b/quickbooks/mixins.py
@@ -46,8 +46,9 @@ class ReadMixin(object):
     qbo_object_name = ""
 
     @classmethod
-    def get(cls, id):
-        qb = QuickBooks()
+    def get(cls, id, qb=None):
+        if not qb:
+            qb = QuickBooks()
 
         json_data = qb.get_single_object(cls.qbo_object_name, pk=id)
         return cls.from_json(json_data[cls.qbo_object_name])
@@ -56,8 +57,9 @@ class ReadMixin(object):
 class UpdateMixin(object):
     qbo_object_name = ""
 
-    def save(self):
-        qb = QuickBooks()
+    def save(self, qb=None):
+        if not qb:
+            qb = QuickBooks()
 
         if self.Id and self.Id > 0:
             json_data = qb.update_object(self.qbo_object_name, self.to_json())
@@ -74,31 +76,31 @@ class ListMixin(object):
     qbo_object_name = ""
 
     @classmethod
-    def all(cls, start_position="", max_results=100):
+    def all(cls, start_position="", max_results=100, qb=None):
         """
         :param max_results: The maximum number of entities that can be returned in a response is 1000.
         :return: Returns list
         """
-        return cls.where("", start_position=start_position, max_results=max_results)
+        return cls.where("", start_position=start_position, max_results=max_results, qb=qb)
 
     @classmethod
-    def filter(cls, start_position="", max_results="", **kwargs):
+    def filter(cls, start_position="", max_results="", qb=None, **kwargs):
         """
         :param kwargs: field names and values to filter the query
         :return: Filtered list
         """
-        return cls.where(build_where_clause(**kwargs), start_position=start_position, max_results=max_results)
+        return cls.where(build_where_clause(**kwargs), start_position=start_position, max_results=max_results, qb=qb)
 
     @classmethod
-    def choose(cls, choices, field="Id"):
+    def choose(cls, choices, field="Id", qb=None):
         """
         :param kwargs: field names and values to filter the query
         :return: Filtered list
         """
-        return cls.where(build_choose_clause(choices, field))
+        return cls.where(build_choose_clause(choices, field), qb=qb)
 
     @classmethod
-    def where(cls, where_clause="", start_position="", max_results=""):
+    def where(cls, where_clause="", start_position="", max_results="", qb=None):
         """
         :param where_clause: QBO SQL where clause (DO NOT include 'WHERE')
         :return: Returns list filtered by input where_clause
@@ -114,16 +116,16 @@ class ListMixin(object):
 
         select = "SELECT * FROM {0} {1}{2}{3}".format(cls.qbo_object_name, where_clause, start_position, max_results)
 
-        return cls.query(select)
+        return cls.query(select, qb=qb)
 
     @classmethod
-    def query(cls, select):
+    def query(cls, select, qb=None):
         """
         :param select: QBO SQL query select statement
         :return: Returns list
         """
-
-        qb = QuickBooks()
+        if not qb:
+            qb = QuickBooks()
 
         json_data = qb.query(select)
 

--- a/tests/integration/test_account.py
+++ b/tests/integration/test_account.py
@@ -7,7 +7,7 @@ from quickbooks.objects.account import Account
 
 class AccountTest(unittest.TestCase):
     def setUp(self):
-        QuickBooks(
+        self.qb_client = QuickBooks(
             sandbox=True,
             consumer_key=os.environ.get('CONSUMER_KEY'),
             consumer_secret=os.environ.get('CONSUMER_SECRET'),
@@ -24,10 +24,10 @@ class AccountTest(unittest.TestCase):
         account.AcctNum = self.account_number
         account.Name = self.name
         account.AccountSubType = "CashOnHand"
-        account.save()
+        account.save(qb=self.qb_client)
 
         self.id = account.Id
-        query_account = Account.get(account.Id)
+        query_account = Account.get(account.Id, qb=self.qb_client)
 
         self.assertEquals(account.Id, query_account.Id)
         self.assertEquals(query_account.Name, self.name)
@@ -37,8 +37,8 @@ class AccountTest(unittest.TestCase):
         account = Account.filter(Name=self.name)[0]
 
         account.Name = "Updated Name {0}".format(self.account_number)
-        account.save()
+        account.save(qb=self.qb_client)
 
-        query_account = Account.get(account.Id)
+        query_account = Account.get(account.Id, qb=self.qb_client)
 
         self.assertEquals(query_account.Name, "Updated Name {0}".format(self.account_number))

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -10,7 +10,22 @@ class ClientTest(unittest.TestCase):
     def setUp(self):
         pass
 
+    def setUp(self):
+        """
+        Use a consistent set of defaults.
+        """
+        client.QuickBooks(
+            sandbox=True,
+            consumer_key="update_consumer_key",
+            consumer_secret="update_consumer_secret",
+            access_token="update_access_token",
+            access_token_secret="update_access_token_secret",
+            company_id="update_company_id",
+            callback_url="update_callback_url"
+        )
+
     def tearDown(self):
+        client.QuickBooks.enable_global()
         self.qb_client = client.QuickBooks()
         self.qb_client._drop()
 
@@ -72,6 +87,19 @@ class ClientTest(unittest.TestCase):
         self.assertEquals(self.qb_client2.access_token_secret, "update_access_token_secret")
         self.assertEquals(self.qb_client2.company_id, "update_company_id")
         self.assertEquals(self.qb_client2.callback_url, "update_callback_url")
+
+    def test_disable_global(self):
+        client.QuickBooks.disable_global()
+        self.qb_client = client.QuickBooks()
+
+        self.assertFalse(self.qb_client.sandbox)
+        self.assertFalse(self.qb_client.consumer_key)
+        self.assertFalse(self.qb_client.consumer_secret)
+        self.assertFalse(self.qb_client.access_token)
+        self.assertFalse(self.qb_client.access_token_secret)
+        self.assertFalse(self.qb_client.company_id)
+        self.assertFalse(self.qb_client.callback_url)
+        self.assertFalse(self.qb_client.minorversion)
 
     def test_api_url(self):
         qb_client = client.QuickBooks(sandbox=False)
@@ -186,8 +214,7 @@ class ClientTest(unittest.TestCase):
 
         qb_session.request.assert_called_with(
                 "GET", url, True, "1234", data={},
-                headers={'Content-Type': 'application/json', 'Accept': 'application/json'},
-                params={'minorversion': 4})
+                headers={'Content-Type': 'application/json', 'Accept': 'application/json'}, params={})
 
     def test_handle_exceptions(self):
         qb_client = client.QuickBooks()

--- a/tests/unit/test_mixins.py
+++ b/tests/unit/test_mixins.py
@@ -1,5 +1,7 @@
 import unittest
-from mock import patch
+from mock import patch, Mock
+
+from quickbooks import client
 
 from quickbooks.objects.base import PhoneNumber
 from quickbooks.objects.department import Department
@@ -16,20 +18,46 @@ class ToJsonMixinTest(unittest.TestCase):
 
 
 class ListMixinTest(unittest.TestCase):
+    def setUp(self):
+        self.qb_client = client.QuickBooks(
+            sandbox=True,
+            consumer_key="update_consumer_key",
+            consumer_secret="update_consumer_secret",
+            access_token="update_access_token",
+            access_token_secret="update_access_token_secret",
+            company_id="update_company_id",
+            callback_url="update_callback_url"
+        )
+
     @patch('quickbooks.mixins.ListMixin.where')
     def test_all(self, where):
         Department.all()
-        where.assert_called_once_with('', max_results=100, start_position='')
+        where.assert_called_once_with('', max_results=100, start_position='', qb=None)
+
+    def test_all_with_qb(self):
+        with patch.object(self.qb_client, 'query') as query:
+            Department.all(qb=self.qb_client)
+            self.assertTrue(query.called)
 
     @patch('quickbooks.mixins.ListMixin.where')
     def test_filter(self, where):
         Department.filter(max_results=25, start_position='1', Active=True)
-        where.assert_called_once_with("Active = True", max_results=25, start_position='1')
+        where.assert_called_once_with("Active = True", max_results=25, start_position='1', qb=None)
+
+    def test_filter_with_qb(self):
+        with patch.object(self.qb_client, 'query') as query:
+            Department.filter(Active=True, qb=self.qb_client)
+            self.assertTrue(query.called)
 
     @patch('quickbooks.mixins.ListMixin.query')
     def test_where(self, query):
         Department.where("Active=True", 1, 10)
-        query.assert_called_once_with("SELECT * FROM Department WHERE Active=True STARTPOSITION 1 MAXRESULTS 10")
+        query.assert_called_once_with("SELECT * FROM Department WHERE Active=True STARTPOSITION 1 MAXRESULTS 10", qb=None)
+
+    def test_where_with_qb(self):
+        with patch.object(self.qb_client, 'query') as query:
+            Department.where("Active=True", 1, 10, qb=self.qb_client)
+            self.assertTrue(query.called)
 
     @patch('quickbooks.mixins.QuickBooks.query')
     def test_query(self, query):
@@ -37,25 +65,69 @@ class ListMixinTest(unittest.TestCase):
         Department.query(select)
         query.assert_called_once_with(select)
 
+    def test_query_with_qb(self):
+        with patch.object(self.qb_client, 'query') as query:
+            select = "SELECT * FROM Department WHERE Active=True"
+            Department.query(select, qb=self.qb_client)
+            self.assertTrue(query.called)
+
     @patch('quickbooks.mixins.ListMixin.where')
     def test_choose(self, where):
         Department.choose(['name1', 'name2'], field="Name")
-        where.assert_called_once_with("Name in ('name1', 'name2')")
+        where.assert_called_once_with("Name in ('name1', 'name2')", qb=None)
+
+    def test_choose_with_qb(self):
+        with patch.object(self.qb_client, 'query') as query:
+            Department.choose(['name1', 'name2'], field="Name", qb=self.qb_client)
+            self.assertTrue(query.called)
 
 
 class ReadMixinTest(unittest.TestCase):
+    def setUp(self):
+        self.qb_client = client.QuickBooks(
+            sandbox=True,
+            consumer_key="update_consumer_key",
+            consumer_secret="update_consumer_secret",
+            access_token="update_access_token",
+            access_token_secret="update_access_token_secret",
+            company_id="update_company_id",
+            callback_url="update_callback_url"
+        )
+
     @patch('quickbooks.mixins.QuickBooks.get_single_object')
     def test_get(self, get_single_object):
         Department.get(1)
         get_single_object.assert_called_once_with("Department", pk=1)
 
+    def test_get_with_qb(self):
+        with patch.object(self.qb_client, 'get_single_object') as get_single_object:
+            Department.get(1, qb=self.qb_client)
+            self.assertTrue(get_single_object.called)
+
 
 class UpdateMixinTest(unittest.TestCase):
+    def setUp(self):
+        self.qb_client = client.QuickBooks(
+            sandbox=True,
+            consumer_key="update_consumer_key",
+            consumer_secret="update_consumer_secret",
+            access_token="update_access_token",
+            access_token_secret="update_access_token_secret",
+            company_id="update_company_id",
+            callback_url="update_callback_url"
+        )
+
     @patch('quickbooks.mixins.QuickBooks.create_object')
     def test_save_create(self, create_object):
         department = Department()
         department.save()
         create_object.assert_called_once_with("Department", department.to_json())
+
+    def test_save_create_with_qb(self):
+        with patch.object(self.qb_client, 'create_object') as create_object:
+            department = Department()
+            department.save()
+            self.assertTrue(create_object.called)
 
     @patch('quickbooks.mixins.QuickBooks.update_object')
     def test_save_update(self, update_object):
@@ -65,3 +137,12 @@ class UpdateMixinTest(unittest.TestCase):
 
         department.save()
         update_object.assert_called_once_with("Department", json)
+
+    def test_save_update_with_qb(self):
+        with patch.object(self.qb_client, 'update_object') as update_object:
+            department = Department()
+            department.Id = 1
+            json = department.to_json()
+
+            department.save()
+            self.assertTrue(update_object.called)


### PR DESCRIPTION
We're using python-quickbooks within our Django app and work with multiple sets of access_tokens and oauth credentials. To ensure that we're pushing QuickBooks objects to the correct accounts, I've added:

1. A method to the QuickBooks class for disabling using of the singleton pattern called 'disable_global'.
2. An extra kwarg called 'qb' to the mixin and batch methods that allow the developer to specify which QuickBooks client should be used when making a request.

All changes are backwards compatible. If you plan on accepting this pull request, I can follow up with a completion of unit tests and documentation.