### PR TITLE
authorize url keeps the query parameters

### DIFF
--- a/quickbooks/client.py
+++ b/quickbooks/client.py
@@ -116,8 +116,7 @@ class QuickBooks(object):
         Returns the Authorize URL as returned by QB, and specified by OAuth 1.0a.
         :return URI:
         """
-        if '?' in self.authorize_url:
-            self.authorize_url = self.authorize_url[:self.authorize_url.find('?')]
+        self.authorize_url = self.authorize_url[:self.authorize_url.find('?')] if '?' in self.authorize_url else self.authorize_url
         if self.qbService is None:
             self.set_up_service()
 

--- a/quickbooks/client.py
+++ b/quickbooks/client.py
@@ -116,7 +116,8 @@ class QuickBooks(object):
         Returns the Authorize URL as returned by QB, and specified by OAuth 1.0a.
         :return URI:
         """
-        self.authorize_url = self.authorize_url[:self.authorize_url.find('?')]
+        if '?' in self.authorize_url:
+            self.authorize_url = self.authorize_url[:self.authorize_url.find('?')]
         if self.qbService is None:
             self.set_up_service()
 

--- a/quickbooks/client.py
+++ b/quickbooks/client.py
@@ -116,6 +116,7 @@ class QuickBooks(object):
         Returns the Authorize URL as returned by QB, and specified by OAuth 1.0a.
         :return URI:
         """
+        self.authorize_url = self.authorize_url[:self.authorize_url.find('?')]
         if self.qbService is None:
             self.set_up_service()
 


### PR DESCRIPTION
Authorize URL keeps repeating the old oauth_token which leads to ?oauth_token=abc123?oauth_token=cba321. That raises internal error within QBO.