### PR TITLE
Fix SalesReceipt initialization...

### DIFF
--- a/quickbooks/objects/salesreceipt.py
+++ b/quickbooks/objects/salesreceipt.py
@@ -40,21 +40,21 @@ class SalesReceipt(QuickbooksManagedObject, QuickbooksTransactionEntity, LinkedT
         self.DocNumber = ""
         self.TxnDate = ""
         self.PrivateNote = ""
-        self.CustomerMemo = ""
         self.ShipDate = ""
         self.TrackingNum = ""
         self.TotalAmt = 0
         self.PrintStatus = "NotSet"
         self.EmailStatus = "NotSet"
-        self.DeliveryInfo = ""
         self.Balance = 0
         self.PaymentRefNum = ""
-        self.CreditCardPayment = ""
-        self.TxnSource = ""
         self.ApplyTaxAfterDiscount = False
         self.ExchangeRate = 1
         self.GlobalTaxCalculation = "TaxExcluded"
 
+        self.CustomerMemo = None
+        self.DeliveryInfo = None
+        self.CreditCardPayment = None
+        self.TxnSource = None
         self.DepartmentRef = None
         self.CurrencyRef = None
         self.TxnTaxDetail = None


### PR DESCRIPTION
initialize empty objects instead of empty strings.

In order to create a new sales receipt I had to set those attributes to `None` to make it work. With this patch this won't be necessary.