### PR TITLE
resolve some errors while accessing object attribute for some particular objects.

### DIFF
--- a/quickbooks/objects/billpayment.py
+++ b/quickbooks/objects/billpayment.py
@@ -67,7 +67,7 @@ class BillPayment(QuickbooksManagedObject, QuickbooksTransactionEntity, LinkedTx
         "CreditCardPayment": BillPaymentCreditCard,
         "APAccountRef": Ref,
         "DepartmentRef": Ref,
-
+        "CurrencyRef" : Ref
     }
 
     list_dict = {

--- a/quickbooks/objects/taxrate.py
+++ b/quickbooks/objects/taxrate.py
@@ -10,6 +10,7 @@ class TaxRate(QuickbooksManagedObject, QuickbooksTransactionEntity):
     """
     class_dict = {
         "AgencyRef": Ref
+        ,"TaxReturnLineRef" : Ref
     }
 
     qbo_object_name = "TaxRate"


### PR DESCRIPTION
It resolves `object doesn't have attribute "Value/value" ` errors for billpayment and taxrates/taxcodes objects while accessing some attributes in object style.
so instead of taxrate["Value"] or taxrate.get("Value") we can access it via taxrate.Value