### PR TITLE
Add method to client to disconnect a QB account

### DIFF
--- a/quickbooks/client.py
+++ b/quickbooks/client.py
@@ -38,6 +38,8 @@ class QuickBooks(object):
 
     authorize_url = "https://appcenter.intuit.com/Connect/Begin"
 
+    disconnect_url = "https://appcenter.intuit.com/api/v1/connection/disconnect"
+
     request_token = ''
     request_token_secret = ''
 
@@ -179,6 +181,12 @@ class QuickBooks(object):
         self.access_token_secret = session.access_token_secret
 
         return session
+
+    def disconnect_account(self):
+        '''Disconnect this account from the application'''
+        url = self.disconnect_url
+        result = self.make_request("GET", url)
+        return result
 
     def make_request(self, request_type, url, request_body=None, content_type='application/json'):
         params = {}

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -177,6 +177,15 @@ class ClientTest(unittest.TestCase):
         qbService.get_auth_session.assert_called_with('token', 'secret', data={'oauth_verifier': 'oauth_verifier'})
         self.assertFalse(session is None)
 
+    @patch('quickbooks.client.QuickBooks.make_request')
+    def test_disconnect_account(self, make_req):
+        qb_client = client.QuickBooks()
+        qb_client.company_id = "1234"
+
+        result = qb_client.disconnect_account()
+        url = "https://appcenter.intuit.com/api/v1/connection/disconnect"
+        make_req.assert_called_with("GET", url)
+
     def test_get_instance(self):
         qb_client = client.QuickBooks()
 


### PR DESCRIPTION
The client now has a way of disconnecting a Quickbooks Account.

This is required for almost all Quickbooks applications. References here: https://developer.intuit.com/docs/0050_quickbooks_api/0020_authentication_and_authorization/oauth_management_api#/Disconnect