### PR TITLE
added OAuth token renewal

### DIFF
--- a/quickbooks/client.py
+++ b/quickbooks/client.py
@@ -42,6 +42,7 @@ class QuickBooks(object):
     authorize_url = "https://appcenter.intuit.com/Connect/Begin"
 
     disconnect_url = "https://appcenter.intuit.com/api/v1/connection/disconnect"
+    reconnect_url = "https://appcenter.intuit.com/api/v1/connection/reconnect"
 
     request_token = ''
     request_token_secret = ''
@@ -200,6 +201,15 @@ class QuickBooks(object):
         :return:
         """
         url = self.disconnect_url
+        result = self.make_request("GET", url)
+        return result
+
+    def reconnect_account(self):
+        """
+        Reconnect current account by refreshing OAuth access tokens
+        :return:
+        """
+        url = self.reconnect_url
         result = self.make_request("GET", url)
         return result
 

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -187,6 +187,15 @@ class ClientTest(unittest.TestCase):
         make_req.assert_called_with("GET", url)
 
     @patch('quickbooks.client.QuickBooks.make_request')
+    def test_reconnect_account(self, make_req):
+        qb_client = client.QuickBooks()
+        qb_client.company_id = "1234"
+
+        result = qb_client.reconnect_account()
+        url = "https://appcenter.intuit.com/api/v1/connection/reconnect"
+        make_req.assert_called_with("GET", url)
+
+    @patch('quickbooks.client.QuickBooks.make_request')
     def test_get_report(self, make_req):
         qb_client = client.QuickBooks()
         qb_client.company_id = "1234"


### PR DESCRIPTION
An authorized access token expires after 180 days.  When this occurs, responses to calls to QuickBooks Data Services and the QuickBooks Online API indicate that the access token is invalid.