### PR TITLE
Fix quote escaping in the build choose and where utilities

### DIFF
--- a/quickbooks/utils.py
+++ b/quickbooks/utils.py
@@ -9,7 +9,7 @@ def build_where_clause(**kwargs):
 
         for key, value in kwargs.items():
             if isinstance(value, six.string_types):
-                where.append("{0} = '{1}'".format(key, value.replace("'", "\'")))
+                where.append("{0} = '{1}'".format(key, value.replace("'", "\\'")))
             else:
                 where.append("{0} = {1}".format(key, value))
 
@@ -26,7 +26,7 @@ def build_choose_clause(choices, field):
 
         for choice in choices:
             if isinstance(choice, six.string_types):
-                where.append("'{0}'".format(choice.replace("'", "\'")))
+                where.append("'{0}'".format(choice.replace("'", "\\'")))
             else:
                 where.append("{0}".format(choice))
 

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -11,6 +11,11 @@ class UtilsTests(unittest.TestCase):
 
         self.assertTrue(where_clause, "WHERE field1 = 1 AND field2 = 'value2")
 
+    def test_build_where_clause_quote_strings(self):
+        where_clause = utils.build_where_clause(field1="value2's")
+
+        self.assertEqual(where_clause, "field1 = 'value2\\'s'")
+
     def test_build_where_clause_integers(self):
         where_clause = utils.build_choose_clause(choices=[1, 2], field="field1")
 
@@ -20,3 +25,8 @@ class UtilsTests(unittest.TestCase):
         where_clause = utils.build_choose_clause(choices=["val1", "val2"], field="field1")
 
         self.assertTrue(where_clause, "WHERE field1 in ('val1', 'val2')")
+
+    def test_build_choose_clause_quote_strings(self):
+        where_clause = utils.build_choose_clause(choices=["val1's"], field="field1")
+
+        self.assertEqual(where_clause, "field1 in ('val1\\'s')")


### PR DESCRIPTION
- Modifies build_choose_clause and build_where_clause to format
' with \\' instead of \'. \' will be received by QuickBooks as '
which will break their query parser.