### PR TITLE
Fixed attachable upload error

### DIFF
--- a/quickbooks/client.py
+++ b/quickbooks/client.py
@@ -8,6 +8,7 @@ except ImportError:  # Python 2
 import textwrap
 import json
 import os
+import base64
 from .exceptions import QuickbooksException, SevereException, AuthorizationException
 
 try:
@@ -254,7 +255,10 @@ class QuickBooks(object):
                 'Connection': 'close'
             })
 
-            binary_data = attachment.read()
+            data = base64.b64encode(attachment.read())
+            binary_data = str(data, 'utf-8')
+
+            content_type = json.loads(request_body)['ContentType']
 
             request_body = textwrap.dedent(
                 """
@@ -266,13 +270,14 @@ class QuickBooks(object):
 
                 --%s
                 Content-Disposition: form-data; name="file_content_01"
-                Content-Type: application/pdf
+                Content-Type: %s
+                Content-Transfer-Encoding: base64
 
                 %s
 
                 --%s--
                 """
-            ) % (boundary, request_body, boundary, binary_data, boundary)
+            ) % (boundary, request_body, boundary, content_type, binary_data, boundary)
 
         req = self.session.request(
             request_type, url, True, self.company_id,

--- a/quickbooks/client.py
+++ b/quickbooks/client.py
@@ -8,8 +8,8 @@ except ImportError:  # Python 2
 import textwrap
 import json
 import os
-import base64
 from .exceptions import QuickbooksException, SevereException, AuthorizationException
+import base64
 
 try:
     from rauth import OAuth1Session, OAuth1Service
@@ -255,8 +255,7 @@ class QuickBooks(object):
                 'Connection': 'close'
             })
 
-            data = base64.b64encode(attachment.read())
-            binary_data = str(data, 'utf-8')
+            binary_data = str(base64.b64encode(attachment.read()), 'utf-8')
 
             content_type = json.loads(request_body)['ContentType']
 


### PR DESCRIPTION
Fix for issue https://github.com/sidecars/python-quickbooks/issues/60

There were 2 issues:
1. File `Content-Type` was hardcoded to `application/pdf`, due to which Attachables were getting uploaded but did not open correctly in Quickbooks Online
2. Even pdfs did not open correctly in Quickbooks Online