### PR TITLE
ToDictMixin

### DIFF
--- a/quickbooks/mixins.py
+++ b/quickbooks/mixins.py
@@ -1,4 +1,5 @@
 import simplejson as json
+import six
 from .utils import build_where_clause, build_choose_clause
 from .client import QuickBooks
 from .exceptions import QuickbooksException
@@ -50,9 +51,40 @@ class FromJsonMixin(object):
         return obj
 
 
+# Based on http://stackoverflow.com/a/1118038
+def to_dict(obj, classkey=None):
+    """
+    Recursively converts Python object into a dictionary
+    """
+    if isinstance(obj, dict):
+        data = {}
+        for (k, v) in obj.items():
+            data[k] = to_dict(v, classkey)
+        return data
+    elif hasattr(obj, "_ast"):
+        return to_dict(obj._ast())
+    elif hasattr(obj, "__iter__") and not isinstance(obj, str):
+        return [to_dict(v, classkey) for v in obj]
+    elif hasattr(obj, "__dict__"):
+        if six.PY2:
+            data = dict([(key, to_dict(value, classkey))
+                        for key, value in obj.__dict__.iteritems()
+                        if not callable(value) and not key.startswith('_')])
+        else:
+            data = dict([(key, to_dict(value, classkey))
+                        for key, value in obj.__dict__.items()
+                        if not callable(value) and not key.startswith('_')])
+
+        if classkey is not None and hasattr(obj, "__class__"):
+            data[classkey] = obj.__class__.__name__
+        return data
+    else:
+        return obj
+
+
 class ToDictMixin(object):
     def to_dict(self):
-        return json.loads(self.to_json())
+        return to_dict(self)
 
 
 class ReadMixin(object):

--- a/quickbooks/mixins.py
+++ b/quickbooks/mixins.py
@@ -50,6 +50,11 @@ class FromJsonMixin(object):
         return obj
 
 
+class ToDictMixin(object):
+    def to_dict(self):
+        return json.loads(self.to_json())
+
+
 class ReadMixin(object):
     qbo_object_name = ""
 

--- a/quickbooks/objects/base.py
+++ b/quickbooks/objects/base.py
@@ -1,8 +1,8 @@
 from six import python_2_unicode_compatible
-from ..mixins import ToJsonMixin, FromJsonMixin, ReadMixin, ListMixin, UpdateMixin
+from ..mixins import ToJsonMixin, FromJsonMixin, ReadMixin, ListMixin, UpdateMixin, ToDictMixin
 
 
-class QuickbooksBaseObject(ToJsonMixin, FromJsonMixin):
+class QuickbooksBaseObject(ToJsonMixin, FromJsonMixin, ToDictMixin):
     class_dict = {}
     list_dict = {}
     detail_dict = {}

--- a/quickbooks/objects/base.py
+++ b/quickbooks/objects/base.py
@@ -66,7 +66,7 @@ class Address(QuickbooksBaseObject):
 
 
 @python_2_unicode_compatible
-class PhoneNumber(ToJsonMixin, FromJsonMixin):
+class PhoneNumber(ToJsonMixin, FromJsonMixin, ToDictMixin):
     def __init__(self):
         self.FreeFormNumber = ""
 

--- a/tests/unit/test_mixins.py
+++ b/tests/unit/test_mixins.py
@@ -64,10 +64,59 @@ class FromJsonMixinTest(unittest.TestCase):
 
 class ToDictMixinTest(unittest.TestCase):
     def test_to_dict(self):
-        phone = PhoneNumber()
-        phone.FreeFormNumber = "555-555-5555"
+        json_data = {
+            'DocNumber': '123',
+            'TotalAmt': 100,
+            'Line': [
+                {
+                    "Id": "0",
+                    "Description": "Test",
+                    "Amount": 25.54,
+                    "DetailType": "JournalEntryLineDetail",
+                    "JournalEntryLineDetail": {
+                        "PostingType": "Debit",
+                    }
+                },
+            ],
+        }
 
-        self.assertEquals(phone.to_dict(), {"FreeFormNumber": "555-555-5555"})
+        entry = JournalEntry.from_json(json_data)
+        expected = {
+            'DocNumber': '123',
+            'SyncToken': 0,
+            'domain': 'QBO',
+            'TxnDate': '',
+            'TotalAmt': 100,
+            'ExchangeRate': 1,
+            'CurrencyRef': None,
+            'PrivateNote': '',
+            'sparse': False,
+            'Line': [{
+                'LinkedTxn': [],
+                'Description': 'Test',
+                'JournalEntryLineDetail': {
+                    'TaxAmount': 0,
+                    'Entity': None,
+                    'DepartmentRef': None,
+                    'TaxCodeRef': None,
+                    'BillableStatus': '',
+                    'TaxApplicableOn': 'Sales',
+                    'PostingType': 'Debit',
+                    'AccountRef': None,
+                    'ClassRef': None,
+                },
+                'DetailType': 'JournalEntryLineDetail',
+                'LineNum': 0,
+                'Amount': 25.54,
+                'CustomField': [],
+                'Id': '0',
+            }],
+            'Adjustment': False,
+            'Id': None,
+            'TxnTaxDetail': None,
+        }
+
+        self.assertEquals(expected, entry.to_dict())
 
 
 class ListMixinTest(unittest.TestCase):

--- a/tests/unit/test_mixins.py
+++ b/tests/unit/test_mixins.py
@@ -62,6 +62,14 @@ class FromJsonMixinTest(unittest.TestCase):
         self.assertEquals(new_obj.TotalAmt, 100)
 
 
+class ToDictMixinTest(unittest.TestCase):
+    def test_to_dict(self):
+        phone = PhoneNumber()
+        phone.FreeFormNumber = "555-555-5555"
+
+        self.assertEquals(phone.to_dict(), {"FreeFormNumber": "555-555-5555"})
+
+
 class ListMixinTest(unittest.TestCase):
     def setUp(self):
         self.qb_client = client.QuickBooks(


### PR DESCRIPTION
Too often I would prefer to just see the dictionary of the object to quickly glance through all nested objects and I find myself running `json.loads(obj.to_json())`.

I created the `ToDictMixin` which gives all objects the method `.to_dict()` which returns a dictionary of that object.

Right now it uses the `ToJsonMixin` to hack around it. If you guys have any suggestions on a better approach, happy to dive into that.