### PR TITLE
Delete individual objects

### DIFF
--- a/quickbooks/client.py
+++ b/quickbooks/client.py
@@ -349,6 +349,12 @@ class QuickBooks(object):
 
         return result
 
+    def delete_object(self, qbbo, request_body, _file_path=None):
+        url = self.api_url + "/company/{0}/{1}".format(self.company_id, qbbo.lower())
+        result = self.make_request("POST", url, request_body, params={'operation': 'delete'}, file_path=_file_path)
+
+        return result
+
     def batch_operation(self, request_body):
         url = self.api_url + "/company/{0}/batch".format(self.company_id)
         results = self.make_request("POST", url, request_body)

--- a/quickbooks/mixins.py
+++ b/quickbooks/mixins.py
@@ -80,6 +80,23 @@ class UpdateMixin(object):
         return obj
 
 
+class DeleteMixin(object):
+    qbo_object_name = ""
+
+    def delete(self, qb=None):
+        if not qb:
+            qb = QuickBooks()
+
+        if not self.Id:
+            raise QuickbooksException('Cannot delete unsaved object')
+
+        data = {
+            'Id': self.Id,
+            'SyncToken': self.SyncToken,
+        }
+        return qb.delete_object(self.qbo_object_name, json.dumps(data))
+
+
 class ListMixin(object):
     qbo_object_name = ""
 

--- a/quickbooks/objects/attachable.py
+++ b/quickbooks/objects/attachable.py
@@ -1,10 +1,11 @@
 from six import python_2_unicode_compatible
 from .base import Ref, QuickbooksManagedObject, QuickbooksTransactionEntity, AttachableRef
 from ..client import QuickBooks
+from ..mixins import DeleteMixin
 
 
 @python_2_unicode_compatible
-class Attachable(QuickbooksManagedObject, QuickbooksTransactionEntity):
+class Attachable(DeleteMixin, QuickbooksManagedObject, QuickbooksTransactionEntity):
     """
     QBO definition: This page covers the Attachable, Upload, and Download resources used for attachment management. Attachments are supplemental information linked to a transaction or Item object. They can be files, notes, or a combination of both.
     In the case of file attachments, use an upload endpoint multipart request to upload the files to the QuickBooks attachment list and, optionally, to supply metadata for each via an attachable object. If meta data is not supplied with the upload request, the system creates it.

--- a/quickbooks/objects/bill.py
+++ b/quickbooks/objects/bill.py
@@ -4,10 +4,11 @@ from quickbooks.objects.detailline import DetailLine, ItemBasedExpenseLine, Acco
 from .base import Ref, LinkedTxn, QuickbooksManagedObject, QuickbooksTransactionEntity, \
     LinkedTxnMixin
 from .tax import TxnTaxDetail
+from ..mixins import DeleteMixin
 
 
 @python_2_unicode_compatible
-class Bill(QuickbooksManagedObject, QuickbooksTransactionEntity, LinkedTxnMixin):
+class Bill(DeleteMixin, QuickbooksManagedObject, QuickbooksTransactionEntity, LinkedTxnMixin):
     """
     QBO definition: A Bill entity is an AP transaction representing a request-for-payment from a third party for
     goods/services rendered and/or received.

--- a/quickbooks/objects/billpayment.py
+++ b/quickbooks/objects/billpayment.py
@@ -1,6 +1,7 @@
 from six import python_2_unicode_compatible
 from .base import QuickbooksBaseObject, Ref, LinkedTxn, QuickbooksManagedObject, LinkedTxnMixin, \
     QuickbooksTransactionEntity
+from ..mixins import DeleteMixin
 
 
 @python_2_unicode_compatible
@@ -50,7 +51,7 @@ class BillPaymentLine(QuickbooksBaseObject):
 
 
 @python_2_unicode_compatible
-class BillPayment(QuickbooksManagedObject, QuickbooksTransactionEntity, LinkedTxnMixin):
+class BillPayment(DeleteMixin, QuickbooksManagedObject, QuickbooksTransactionEntity, LinkedTxnMixin):
     """
     QBO definition: A BillPayment entity represents the financial transaction of payment
     of bills that the business owner receives from a vendor for goods or services purchased

--- a/quickbooks/objects/creditmemo.py
+++ b/quickbooks/objects/creditmemo.py
@@ -4,10 +4,11 @@ from quickbooks.objects.detailline import SalesItemLine, SubtotalLine, DiscountL
 from .base import Address, EmailAddress, Ref, CustomField, CustomerMemo, QuickbooksManagedObject, \
     LinkedTxnMixin, QuickbooksTransactionEntity
 from .tax import TxnTaxDetail
+from ..mixins import DeleteMixin
 
 
 @python_2_unicode_compatible
-class CreditMemo(QuickbooksTransactionEntity, QuickbooksManagedObject, LinkedTxnMixin):
+class CreditMemo(DeleteMixin, QuickbooksTransactionEntity, QuickbooksManagedObject, LinkedTxnMixin):
     """
     QBO definition: The CreditMemo is a financial transaction representing a refund or credit of payment or part
     of a payment for goods or services that have been sold.

--- a/quickbooks/objects/deposit.py
+++ b/quickbooks/objects/deposit.py
@@ -1,6 +1,7 @@
 from six import python_2_unicode_compatible
 from .base import QuickbooksBaseObject, Ref, LinkedTxn, QuickbooksManagedObject, LinkedTxnMixin, \
     QuickbooksTransactionEntity, CustomField, AttachableRef
+from ..mixins import DeleteMixin
 
 
 class CashBackInfo(QuickbooksBaseObject):
@@ -63,7 +64,7 @@ class DepositLine(QuickbooksBaseObject):
 
 
 @python_2_unicode_compatible
-class Deposit(QuickbooksManagedObject, QuickbooksTransactionEntity, LinkedTxnMixin):
+class Deposit(DeleteMixin, QuickbooksManagedObject, QuickbooksTransactionEntity, LinkedTxnMixin):
     """
     QBO definition: A deposit object is a transaction that records one or more deposits of the following types:
 

--- a/quickbooks/objects/estimate.py
+++ b/quickbooks/objects/estimate.py
@@ -3,11 +3,11 @@ from .base import CustomField, Ref, CustomerMemo, Address, EmailAddress, Quickbo
     LinkedTxnMixin, QuickbooksTransactionEntity, LinkedTxn
 from .tax import TxnTaxDetail
 from .detailline import DetailLine, SalesItemLine, GroupLine, DescriptionLine, DiscountLine, SubtotalLine
-from ..mixins import QuickbooksPdfDownloadable
+from ..mixins import QuickbooksPdfDownloadable, DeleteMixin
 
 
 @python_2_unicode_compatible
-class Estimate(QuickbooksPdfDownloadable, QuickbooksManagedObject, QuickbooksTransactionEntity, LinkedTxnMixin):
+class Estimate(DeleteMixin, QuickbooksPdfDownloadable, QuickbooksManagedObject, QuickbooksTransactionEntity, LinkedTxnMixin):
     """
     QBO definition: The Estimate represents a proposal for a financial transaction from a business to a customer
     for goods or services proposed to be sold, including proposed pricing.

--- a/quickbooks/objects/invoice.py
+++ b/quickbooks/objects/invoice.py
@@ -3,7 +3,7 @@ from .base import QuickbooksBaseObject, Ref, CustomField, Address, EmailAddress,
     QuickbooksTransactionEntity, LinkedTxn, LinkedTxnMixin
 from .tax import TxnTaxDetail
 from .detailline import DetailLine, SalesItemLine, SubtotalLine, DiscountLine, GroupLine, DescriptionOnlyLine
-from ..mixins import QuickbooksPdfDownloadable
+from ..mixins import QuickbooksPdfDownloadable, DeleteMixin
 
 
 class DeliveryInfo(QuickbooksBaseObject):
@@ -14,7 +14,7 @@ class DeliveryInfo(QuickbooksBaseObject):
 
 
 @python_2_unicode_compatible
-class Invoice(QuickbooksPdfDownloadable, QuickbooksManagedObject, QuickbooksTransactionEntity, LinkedTxnMixin):
+class Invoice(DeleteMixin, QuickbooksPdfDownloadable, QuickbooksManagedObject, QuickbooksTransactionEntity, LinkedTxnMixin):
     """
     QBO definition: An Invoice represents a sales form where the customer pays for a product or service later.
 

--- a/quickbooks/objects/journalentry.py
+++ b/quickbooks/objects/journalentry.py
@@ -3,6 +3,7 @@ from .base import QuickbooksBaseObject, Ref, QuickbooksManagedObject, Quickbooks
     LinkedTxnMixin
 from .tax import TxnTaxDetail
 from .detailline import DetailLine, DescriptionOnlyLine
+from ..mixins import DeleteMixin
 
 
 class Entity(QuickbooksBaseObject):
@@ -16,7 +17,7 @@ class Entity(QuickbooksBaseObject):
         self.EntityRef = None
 
 
-class JournalEntryLineDetail(QuickbooksBaseObject):
+class JournalEntryLineDetail(DeleteMixin, QuickbooksBaseObject):
     class_dict = {
         "Entity": Entity,
         "AccountRef": Ref,

--- a/quickbooks/objects/payment.py
+++ b/quickbooks/objects/payment.py
@@ -2,6 +2,7 @@ from six import python_2_unicode_compatible
 from .base import QuickbooksBaseObject, Ref, LinkedTxn, \
     QuickbooksManagedObject, QuickbooksTransactionEntity
 from .creditcardpayment import CreditCardPayment
+from ..mixins import DeleteMixin
 
 
 @python_2_unicode_compatible
@@ -20,7 +21,7 @@ class PaymentLine(QuickbooksBaseObject):
 
 
 @python_2_unicode_compatible
-class Payment(QuickbooksManagedObject, QuickbooksTransactionEntity):
+class Payment(DeleteMixin, QuickbooksManagedObject, QuickbooksTransactionEntity):
     """
     QBO definition: A Payment entity records a payment in QuickBooks. The payment can be
     applied for a particular customer against multiple Invoices and Credit Memos. It can also

--- a/quickbooks/objects/purchase.py
+++ b/quickbooks/objects/purchase.py
@@ -4,10 +4,11 @@ from quickbooks.objects.detailline import DetailLine, AccountBasedExpenseLine, I
 from .base import Ref, QuickbooksManagedObject, QuickbooksTransactionEntity, LinkedTxnMixin, \
     LinkedTxn, Address
 from .tax import TxnTaxDetail
+from ..mixins import DeleteMixin
 
 
 @python_2_unicode_compatible
-class Purchase(QuickbooksManagedObject, QuickbooksTransactionEntity, LinkedTxnMixin):
+class Purchase(DeleteMixin, QuickbooksManagedObject, QuickbooksTransactionEntity, LinkedTxnMixin):
     """
     QBO definition: This entity represents expenses, such as a purchase made from a vendor.
     There are three types of Purchases: Cash, Check, and Credit Card.

--- a/quickbooks/objects/purchaseorder.py
+++ b/quickbooks/objects/purchaseorder.py
@@ -4,10 +4,11 @@ from quickbooks.objects.detailline import DetailLine, ItemBasedExpenseLine, Acco
 from .base import Ref, Address, QuickbooksManagedObject, LinkedTxnMixin, \
     QuickbooksTransactionEntity, CustomField, LinkedTxn
 from .tax import TxnTaxDetail
+from ..mixins import DeleteMixin
 
 
 @python_2_unicode_compatible
-class PurchaseOrder(QuickbooksManagedObject, QuickbooksTransactionEntity, LinkedTxnMixin):
+class PurchaseOrder(DeleteMixin, QuickbooksManagedObject, QuickbooksTransactionEntity, LinkedTxnMixin):
     """
     QBO definition: The PurchaseOrder entity is a non-posting transaction representing a request to purchase
     goods or services from a third party.

--- a/quickbooks/objects/refundreceipt.py
+++ b/quickbooks/objects/refundreceipt.py
@@ -3,10 +3,11 @@ from .base import Ref, CustomField, QuickbooksManagedObject, \
     LinkedTxnMixin, QuickbooksTransactionEntity, LinkedTxn, Address, EmailAddress
 from .tax import TxnTaxDetail
 from .detailline import DetailLine
+from ..mixins import DeleteMixin
 
 
 @python_2_unicode_compatible
-class RefundReceipt(QuickbooksManagedObject, QuickbooksTransactionEntity, LinkedTxnMixin):
+class RefundReceipt(DeleteMixin, QuickbooksManagedObject, QuickbooksTransactionEntity, LinkedTxnMixin):
     """
     QBO definition: RefundReceipt represents a refund to the customer for a product or service that was given.
     """

--- a/quickbooks/objects/salesreceipt.py
+++ b/quickbooks/objects/salesreceipt.py
@@ -3,11 +3,11 @@ from .base import Ref, CustomField, QuickbooksManagedObject, LinkedTxnMixin, Add
     EmailAddress, QuickbooksTransactionEntity, LinkedTxn
 from .tax import TxnTaxDetail
 from .detailline import DetailLine
-from ..mixins import QuickbooksPdfDownloadable
+from ..mixins import QuickbooksPdfDownloadable, DeleteMixin
 
 
 @python_2_unicode_compatible
-class SalesReceipt(QuickbooksPdfDownloadable, QuickbooksManagedObject,
+class SalesReceipt(DeleteMixin, QuickbooksPdfDownloadable, QuickbooksManagedObject,
                    QuickbooksTransactionEntity, LinkedTxnMixin):
     """
     QBO definition: SalesReceipt represents the sales receipt that is given to a customer.

--- a/quickbooks/objects/timeactivity.py
+++ b/quickbooks/objects/timeactivity.py
@@ -1,9 +1,10 @@
 from six import python_2_unicode_compatible
 from .base import Ref, QuickbooksManagedObject, QuickbooksTransactionEntity, LinkedTxnMixin, AttachableRef
+from ..mixins import DeleteMixin
 
 
 @python_2_unicode_compatible
-class TimeActivity(QuickbooksManagedObject, QuickbooksTransactionEntity, LinkedTxnMixin):
+class TimeActivity(DeleteMixin, QuickbooksManagedObject, QuickbooksTransactionEntity, LinkedTxnMixin):
     """
     QBO definition: The TimeActivity entity represents a record of time worked by a vendor or employee.
     """

--- a/quickbooks/objects/transfer.py
+++ b/quickbooks/objects/transfer.py
@@ -1,9 +1,10 @@
 from six import python_2_unicode_compatible
 from .base import Ref, QuickbooksManagedObject, QuickbooksTransactionEntity, LinkedTxnMixin
+from ..mixins import DeleteMixin
 
 
 @python_2_unicode_compatible
-class Transfer(QuickbooksManagedObject, QuickbooksTransactionEntity, LinkedTxnMixin):
+class Transfer(DeleteMixin, QuickbooksManagedObject, QuickbooksTransactionEntity, LinkedTxnMixin):
     """
     QBO definition: A Transfer represents a transaction where funds are moved between two accounts from the
     company's QuickBooks chart of accounts.

--- a/quickbooks/objects/vendorcredit.py
+++ b/quickbooks/objects/vendorcredit.py
@@ -3,10 +3,11 @@ from six import python_2_unicode_compatible
 from .base import Ref, QuickbooksManagedObject, QuickbooksTransactionEntity, \
     LinkedTxnMixin
 from .detailline import DetailLine, AccountBasedExpenseLine, ItemBasedExpenseLine
+from ..mixins import DeleteMixin
 
 
 @python_2_unicode_compatible
-class VendorCredit(QuickbooksManagedObject, QuickbooksTransactionEntity, LinkedTxnMixin):
+class VendorCredit(DeleteMixin, QuickbooksManagedObject, QuickbooksTransactionEntity, LinkedTxnMixin):
     """
     QBO definition: The Vendor Credit entity is an accounts payable transaction that represents a refund or credit
     of payment for goods or services. It is a credit that a vendor owes you for various reasons such as overpaid

--- a/tests/integration/test_invoice.py
+++ b/tests/integration/test_invoice.py
@@ -46,3 +46,31 @@ class InvoiceTest(unittest.TestCase):
         self.assertEquals(query_invoice.CustomerMemo.value, "Customer Memo")
         self.assertEquals(query_invoice.Line[0].Description, "description")
         self.assertEquals(query_invoice.Line[0].Amount, 100.0)
+
+    def test_delete(self):
+        # First create an invoice
+        invoice = Invoice()
+
+        line = SalesItemLine()
+        line.LineNum = 1
+        line.Description = "description"
+        line.Amount = 100
+        line.SalesItemLineDetail = SalesItemLineDetail()
+        item = Item.all(max_results=1, qb=self.qb_client)[0]
+
+        line.SalesItemLineDetail.ItemRef = item.to_ref()
+        invoice.Line.append(line)
+
+        customer = Customer.all(max_results=1, qb=self.qb_client)[0]
+        invoice.CustomerRef = customer.to_ref()
+
+        invoice.CustomerMemo = CustomerMemo()
+        invoice.CustomerMemo.value = "Customer Memo"
+        invoice.save(qb=self.qb_client)
+
+        # Then delete
+        invoice_id = invoice.Id
+        invoice.delete(qb=self.qb_client)
+
+        query_invoice = Invoice.filter(Id=invoice_id, qb=self.qb_client)
+        self.assertEqual([], query_invoice)


### PR DESCRIPTION
Closes #56 

Adds a `DeleteMixin` which adds a `delete()` method to QuickBooks objects that have a delete operation defined.

Right now I just return the result from the delete request, not sure if you guys recommend doing anything to the object itself? Perhaps removing the `Id`? Let me know if you prefer a different return.