### PR TITLE
Fix to_ref for taxcode

### DIFF
--- a/quickbooks/objects/taxcode.py
+++ b/quickbooks/objects/taxcode.py
@@ -65,7 +65,7 @@ class TaxCode(QuickbooksTransactionEntity, QuickbooksBaseObject, ReadMixin, List
         ref = Ref()
 
         ref.type = self.qbo_object_name
-        ref.value = self.Name
-        ref.name = None
+        ref.value = self.Id
+        ref.name = self.Name
 
         return ref

--- a/tests/unit/objects/test_taxcode.py
+++ b/tests/unit/objects/test_taxcode.py
@@ -20,10 +20,13 @@ class TaxCodeTests(unittest.TestCase):
 
     def test_to_ref(self):
         taxcode = TaxCode()
+        taxcode.Id = 2
         taxcode.Name = "test"
 
         ref = taxcode.to_ref()
-        self.assertEquals(ref.value, "test")
+        self.assertEquals(ref.name, "test")
+        self.assertEquals(ref.type, "TaxCode")
+        self.assertEquals(ref.value, 2)
 
 
 class TaxRateDetailTests(unittest.TestCase):


### PR DESCRIPTION
The quickbooks API expects the value to be the ID not the name see: https://developer.intuit.com/docs/api/accounting/taxcode#readataxcode