### PR TITLE
Fix pdf sending error at python 2

### DIFF
--- a/quickbooks/client.py
+++ b/quickbooks/client.py
@@ -195,6 +195,9 @@ class QuickBooks(object):
                 """
             ) % (boundary, request_body, boundary, content_type, binary_data, boundary)
 
+            # make sure request_body is not unicode (python 2 case)
+            request_body = str(request_body)
+
         req = self.process_request(request_type, url, headers=headers, params=params, data=request_body)
 
         if req.status_code == httplib.UNAUTHORIZED:


### PR DESCRIPTION
I found out that at python 2, if some part of the string at `request_body` is Unicode it will promote the entire string to unicode, so after mounting `request_body` i added the `str` call to make sure it is always `str` type

reference: https://github.com/shazow/urllib3/issues/855