### PR TITLE
Fixed bug in PDF download of lost error details on authentication failure

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,9 @@
 Changelog
 ========
 
+* 0.7.5 (May 11th, 2018)
+    * Fixed bug with reporting authentication failure when attempting to download PDF (previously the error details were "lost")
+
 * 0.7.4 (March 26th, 2018)
     * Fixed bug in SendMixin send method.
     * Added support for send_to email to SendMixin.

--- a/quickbooks/client.py
+++ b/quickbooks/client.py
@@ -315,6 +315,11 @@ class QuickBooks(object):
         response = self.process_request("GET", url, headers=headers)
 
         if response.status_code != httplib.OK:
+
+            if response.status_code == httplib.UNAUTHORIZED:
+                # Note that auth errors have different result structure which can't be parsed by handle_exceptions()
+                raise AuthorizationException("Application authentication failed", detail=response.text)
+
             try:
                 result = response.json()
             except:

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ def read(*parts):
         return fp.read()
 
 
-VERSION = (0, 7, 4)
+VERSION = (0, 7, 5)
 version = '.'.join(map(str, VERSION))
 
 setup(


### PR DESCRIPTION
Fixed bug in PDF download, where an authentication failure resulted in error message of 'Fault', rather than something more meaningful.

The root cause of this is that the auth-failure error response structure is different from other errors (e.g. JSON keys are all lower case) and an attempt to access response["Fault"] therefore failed, generating a key error exception rather than the auth failure exception.