### PR TITLE
add missing LinkedTxn

### DIFF
--- a/quickbooks/objects/bill.py
+++ b/quickbooks/objects/bill.py
@@ -26,6 +26,7 @@ class Bill(DeleteMixin, QuickbooksManagedObject, QuickbooksTransactionEntity, Li
 
     list_dict = {
         "Line": DetailLine,
+        "LinkedTxn": LinkedTxn,
     }
 
     detail_dict = {


### PR DESCRIPTION
`Bill` is only one class missing `LinkedTxn` in `list_dict` property