### PR TITLE
Add handling for different exception types

### DIFF
--- a/quickbooks/client.py
+++ b/quickbooks/client.py
@@ -256,7 +256,7 @@ class QuickBooks(object):
                 raise exceptions.UnsupportedException(message, code, detail)
             elif code >= 600 and code <= 1999:
                 if code == 610:
-                    raise exceptions.NotFoundException(message, code, detail)
+                    raise exceptions.ObjectNotFoundException(message, code, detail)
                 raise exceptions.GeneralException(message, code, detail)
             elif code >= 2000 and code <= 4999:
                 raise exceptions.ValidationException(message, code, detail)

--- a/quickbooks/exceptions.py
+++ b/quickbooks/exceptions.py
@@ -43,3 +43,11 @@ class SevereException(QuickbooksException):
     Quickbooks Error Codes greater than 10000
     """
     pass
+
+
+class ObjectNotFoundException(QuickbooksException):
+    """
+    Quickbooks Error Code 610
+    """
+    pass
+


### PR DESCRIPTION
Most of the exceptions in `exceptions.py` don't seem to be used. This updates the client to raise the appropriate exception. I've also added `ObjectNotFoundException` as handling this during a `.get()` call is a very common use case.