### PR TITLE
Make sure the next request after refreshing the auth token starts a n…

### DIFF
--- a/quickbooks/auth.py
+++ b/quickbooks/auth.py
@@ -269,5 +269,6 @@ class Oauth2SessionManager(AuthSessionManager):
             'refresh_token': refresh_token or self.refresh_token,
             'grant_type': 'refresh_token'
         }
+        self.started = False
         return self.token_request(payload, return_result=return_result)
 

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -147,6 +147,7 @@ class Oauth2SessionManagerTest(unittest.TestCase):
             'refresh_token':'refresh_token',                                    
             'grant_type': 'refresh_token'
         }
+        self.assertEqual(self.session_manager.started, False)
         token_request.assert_called_with(payload, return_result=False)
 
     def test_init(self):


### PR DESCRIPTION
…ew session with the new token.

Otherwise the subsequent requests still use the old token and continue to bomb.