### PR TITLE
some DetailLine.DetailType strings were misspelled

### DIFF
--- a/quickbooks/objects/detailline.py
+++ b/quickbooks/objects/detailline.py
@@ -82,7 +82,7 @@ class SubtotalLine(DetailLine):
 
     def __init__(self):
         super(SubtotalLine, self).__init__()
-        self.DetailType = "SubtotalLineDetail"
+        self.DetailType = "SubTotalLineDetail"
         self.SubtotalLineDetail = None
 
 
@@ -157,8 +157,8 @@ class GroupLine(DetailLine):
 
     def __init__(self):
         super(GroupLine, self).__init__()
-        self.DetailType = "SalesItemLineDetail"
-        self.SalesItemLineDetail = None
+        self.DetailType = "GroupLineDetail"
+        self.GroupLineDetail = None
 
 
 class DescriptionOnlyLine(DetailLine):
@@ -168,7 +168,7 @@ class DescriptionOnlyLine(DetailLine):
 
     def __init__(self):
         super(DescriptionOnlyLine, self).__init__()
-        self.DetailType = "DescriptionLineDetail"
+        self.DetailType = "DescriptionOnly"
         self.DescriptionLineDetail = None
 
 

--- a/tests/unit/objects/test_detailline.py
+++ b/tests/unit/objects/test_detailline.py
@@ -52,7 +52,7 @@ class SubtotalLineTest(unittest.TestCase):
     def test_init(self):
         subtotal_line = SubtotalLine()
 
-        self.assertEquals(subtotal_line.DetailType, "SubtotalLineDetail")
+        self.assertEquals(subtotal_line.DetailType, "SubTotalLineDetail")
         self.assertEquals(subtotal_line.SubtotalLineDetail, None)
 
 
@@ -92,8 +92,8 @@ class GroupLineTest(unittest.TestCase):
     def test_init(self):
         line = GroupLine()
 
-        self.assertEquals(line.DetailType, "SalesItemLineDetail")
-        self.assertEquals(line.SalesItemLineDetail, None)
+        self.assertEquals(line.DetailType, "GroupLineDetail")
+        self.assertEquals(line.GroupLineDetail, None)
 
 
 class ItemBasedExpenseLineDetailTest(unittest.TestCase):
@@ -132,5 +132,5 @@ class DescriptionOnlyLineTests(unittest.TestCase):
     def test_unicode(self):
         line = DescriptionOnlyLine()
 
-        self.assertEquals(line.DetailType, "DescriptionLineDetail")
+        self.assertEquals(line.DetailType, "DescriptionOnly")
         self.assertEquals(line.DescriptionLineDetail, None)


### PR DESCRIPTION
when trying to create an invoice with a subtotal line i got this error from detail...

`{"Fault":{"Error":[{"Message":"Request has invalid or unsupported property","Detail":"Property Name:Can not deserialize value of type com.intuit.schema.finance.v3.LineDetailTypeEnum from String \"SubtotalLineDetail\": value not one of declared Enum instance names: [JournalEntryLineDetail ,DepositLineDetail, SalesItemLineDetail, PurchaseOrderItemLineDetail, DiscountLineDetail, TDSLineDetail, SubTotalLineDetail, ItemReceiptLineDetail, PaymentLineDetail, TaxLineDetail, AccountBasedExpenseLineDetail, SalesOrderItemLineDetail, ItemBasedExpenseLineDetail, GroupLineDetail, DescriptionOnly]\n  specified is unsupported or invalid","code":"2010"}],"type":"ValidationFault"},"time":"2019-01-18T16:30:18.560-08:00"}
`

there is a typo in the DetailType string assigned for SubTotalLine
`SubtotalLineDetail` != `SubTotalLineDetail`

while i was at it I also noticed that `DescriptionOnlyLine` and `GroupLineDetail` were miss typed.

