### PR TITLE
Allow start_position 0 but avoid bad-formed query

### DIFF
--- a/quickbooks/mixins.py
+++ b/quickbooks/mixins.py
@@ -226,7 +226,7 @@ class ListMixin(object):
         if order_by:
             order_by = " ORDERBY " + order_by
 
-        if start_position:
+        if start_position != "":
             start_position = " STARTPOSITION " + str(start_position)
 
         if max_results:

--- a/tests/unit/test_mixins.py
+++ b/tests/unit/test_mixins.py
@@ -163,6 +163,8 @@ class ListMixinTest(QuickbooksUnitTestCase):
         query.assert_called_once_with("SELECT * FROM Department WHERE Active=True STARTPOSITION 1 MAXRESULTS 10",
                                       qb=None)
 
+    @patch('quickbooks.mixins.ListMixin.query')
+    def test_where_start_position_0(self, query):
         Department.where("Active=True", start_position=0, max_results=10)
         query.assert_called_once_with("SELECT * FROM Department WHERE Active=True STARTPOSITION 0 MAXRESULTS 10",
                                       qb=None)

--- a/tests/unit/test_mixins.py
+++ b/tests/unit/test_mixins.py
@@ -163,6 +163,10 @@ class ListMixinTest(QuickbooksUnitTestCase):
         query.assert_called_once_with("SELECT * FROM Department WHERE Active=True STARTPOSITION 1 MAXRESULTS 10",
                                       qb=None)
 
+        Department.where("Active=True", start_position=0, max_results=10)
+        query.assert_called_once_with("SELECT * FROM Department WHERE Active=True STARTPOSITION 0 MAXRESULTS 10",
+                                      qb=None)
+
     def test_where_with_qb(self):
         with patch.object(self.qb_client, 'query') as query:
             Department.where("Active=True", start_position=1, max_results=10, qb=self.qb_client)


### PR DESCRIPTION
The start_position of `0` evaluates to `False` so the `STARTPOSITION` is not added to the where clause, but it gets included in `select` variable, leading to bad-formed queries as a result.

Example:

```
(Pdb) select
'SELECT * FROM Account 0 MAXRESULTS 1000'
```

However, the 0 value for `start_position` is accepted by the API so makes sense to allow it. The API considers it as 1. 